### PR TITLE
Add helpful module settings block.

### DIFF
--- a/config/Coldbox.cfc
+++ b/config/Coldbox.cfc
@@ -100,6 +100,12 @@
 		];
 
 		/*
+		// module setting overrides
+		moduleSettings = {
+			moduleName = {
+				settingName = "overrideValue"
+			}
+		};
 
 		// flash scope configuration
 		flash = {


### PR DESCRIPTION
This block is commented out by default in the `config/ColdBox.cfc`.
It will help users realize that all module settings can be overridden from their own config file.